### PR TITLE
Launcher class name fix, a bit of debugging instead of .unwrap() in field resolution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
     let args = matches.values_of_lossy("ARGS");
     println!("main class: {}, args: {:?}", class, args);
 
-    let mut thread = JavaMainThread::new(class, args);
+    let mut thread = JavaMainThread::new(class.replace(".", "/"), args);
     thread.run();
 
     /*

--- a/src/oop/class.rs
+++ b/src/oop/class.rs
@@ -118,7 +118,7 @@ pub fn init_class_fully(thread: &mut JavaThread, class: ClassRef) {
 pub fn load_and_init(jt: &mut JavaThread, name: &[u8]) -> ClassRef {
     // trace!("load_and_init 1 name={}", String::from_utf8_lossy(name));
     let cls_name = unsafe { std::str::from_utf8_unchecked(name) };
-    let class = runtime::require_class3(None, name).expect(cls_name);
+    let class = runtime::require_class3(None, name).unwrap_or_else(|| panic!("Class not found: {}", cls_name));
     // trace!("load_and_init 2 name={}", String::from_utf8_lossy(name));
     {
         let mut class = class.write().unwrap();

--- a/src/oop/field.rs
+++ b/src/oop/field.rs
@@ -16,7 +16,9 @@ pub fn get_field_ref(
     let (class_index, name_and_type_index) = constant_pool::get_field_ref(cp, idx);
 
     //load Field's Class, then init it
-    let class = require_class2(class_index, cp).unwrap();
+    let class = require_class2(class_index, cp).unwrap_or_else(|| {
+        panic!("Unknown field class {:?}", cp.get(class_index as usize).expect("Missing item").as_cp_item(cp))
+    });
     let (name, desc) = {
         let mut class = class.write().unwrap();
         class.init_class(thread);

--- a/src/oop/method.rs
+++ b/src/oop/method.rs
@@ -20,7 +20,9 @@ pub fn get_method_ref(
     let (tag, class_index, name_and_type_index) = constant_pool::get_method_ref(cp, idx);
 
     //load Method's Class, then init it
-    let class = require_class2(class_index, cp).unwrap();
+    let class = require_class2(class_index, cp).unwrap_or_else(|| {
+        panic!("Unknown method class {:?}", cp.get(class_index as usize).expect("Missing item").as_cp_item(cp))
+    });
 
     {
         let mut class = class.write().unwrap();

--- a/src/runtime/java_call.rs
+++ b/src/runtime/java_call.rs
@@ -188,7 +188,12 @@ impl JavaCall {
                     Err(ex) => Err(ex),
                 }
             }
-            None => unreachable!("NotFound native method"),
+            None => panic!(
+                "Native method not found: {:?} {:?} {:?}",
+                std::str::from_utf8(&package),
+                std::str::from_utf8(&name),
+                std::str::from_utf8(&desc),
+            ),
         };
 
         match v {


### PR DESCRIPTION
What about also moving get_class_name/get_field_ref/another to a helper struct, which can also hold cp? (I.e mine ConstantPoolItem)